### PR TITLE
Make the stubs for Code/FunctionType classes.

### DIFF
--- a/pwnypack/pickle.py
+++ b/pwnypack/pickle.py
@@ -219,12 +219,12 @@ def pickle_func(func, target=None, protocol=None, b64encode=None, *args):
                                 code.co_filename, code.co_name, code.co_firstlineno, co_lnotab)
 
     # Stubs to trick cPickle into pickling calls to CodeType/FunctionType.
-    def CodeType(*args):  # pragma: no cover
+    class CodeType(object):  # pragma: no cover
         pass
     CodeType.__module__ = 'types'
     CodeType.__qualname__ = 'CodeType'
 
-    def FunctionType(*args, **kwargs):  # pragma: no cover
+    class FunctionType(object):  # pragma: no cover
         pass
     FunctionType.__module__ = 'types'
     FunctionType.__qualname__ = 'FunctionType'


### PR DESCRIPTION
This enhances compatibility with code that calls isinstance while the
stubs are active. Be aware that tests against these stubs will probably
fail (inspect.isfunction will return false for example).