### PR TITLE
Fix building of pwnypack:py3 docker image.

### DIFF
--- a/docker/pwnypack/py2/Dockerfile
+++ b/docker/pwnypack/py2/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Ingmar Steen <iksteen@gmail.com>
 
 RUN apt-get update && \
 	DEBIAN_FRONTEND=noninteractive apt-get install -qy \
-		git nasm build-essential python \
+		git nasm build-essential python cmake \
 		python-dev python-pip python-virtualenv python-setuptools \
 		binutils-aarch64-linux-gnu binutils-arm-none-eabi \
 		libffi-dev libssl-dev && \

--- a/docker/pwnypack/py3/Dockerfile
+++ b/docker/pwnypack/py3/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Ingmar Steen <iksteen@gmail.com>
 
 RUN apt-get update && \
 	DEBIAN_FRONTEND=noninteractive apt-get install -qy \
-		git nasm build-essential python3 \
+		git nasm build-essential python python3 cmake \
 		python3-dev python3-pip python3-setuptools \
 		binutils-aarch64-linux-gnu binutils-arm-none-eabi \
 		libffi-dev libssl-dev && \


### PR DESCRIPTION
Keystone-engine requires cmake and python2 to build.